### PR TITLE
Testing and linting configured on pre-commit

### DIFF
--- a/dummy.test.tsx
+++ b/dummy.test.tsx
@@ -1,0 +1,5 @@
+describe("Dummy test to configure hooks", () => {
+  it("does something obvious", () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "type": "git",
     "url": "git+https://github.com/Shriram-Balaji/cast-bucket.git"
   },
-  "precommit": "NODE_ENV=production lint-staged",
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn test && lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "tslint --fix",


### PR DESCRIPTION
Husky configuration is now properly set to run tests and lint files on the pre-commit hook. I had to create a dummy test just for `yarn test` to run, but once you have your own tests you can remove this file!

Here's an example of it in action, running tests and linter:
![ezgif-2-74b4308ab0b7](https://user-images.githubusercontent.com/15076656/66268813-d5e01580-e849-11e9-91f7-cc412513227e.gif)

(Closes https://github.com/cast-bucket/cast-bucket/issues/58)